### PR TITLE
change default params for RLWE and MLWE

### DIFF
--- a/module-lwe/src/lib.rs
+++ b/module-lwe/src/lib.rs
@@ -13,9 +13,9 @@ pub struct Parameters {
 
 impl Default for Parameters {
     fn default() -> Self {
-        let n = 4;
+        let n = 16;
         let q = 67;
-        let k = 2;
+        let k = 32;
         let mut poly_vec = vec![0i64;n+1];
         poly_vec[0] = 1;
         poly_vec[n] = 1;

--- a/ring-lwe/src/lib.rs
+++ b/ring-lwe/src/lib.rs
@@ -11,7 +11,7 @@ pub struct Parameters {
 
 impl Default for Parameters {
     fn default() -> Self {
-        let n = 16;
+        let n = 256;
         let q = 32_768;
         let t = 256;
         let mut poly_vec = vec![0i64;n+1];


### PR DESCRIPTION
- we default to more secure parameters
- one can choose less secure parameters optionally