### PR TITLE
add MIT license badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # lattice-based-rust
 
 ![example workflow](https://github.com/jacksonwalters/lattice-based-rust/actions/workflows/basic.yml/badge.svg)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 Lattice-based encryption methods (ring-LWE, module-LWE) in pure Rust.
 


### PR DESCRIPTION
display the MIT license badge in markdown on the README