### PR TITLE
remove extra default params, fix nearest_int

### DIFF
--- a/ring-lwe/src/lib.rs
+++ b/ring-lwe/src/lib.rs
@@ -144,11 +144,7 @@ pub fn gen_normal_poly(size: usize, seed: Option<u64>) -> Polynomial<i64> {
 	Polynomial::new(coeffs)
 }
 
+//returns the nearest integer to a/b
 pub fn nearest_int(a: i64, b: i64) -> i64 {
-    //Returns the nearest integer to a/b
-    //Args: i64 a, i64 b
-    //Returns: i64 \lfloor a/b + 0.5 \rfloor
-
-    (a as f64 / b as f64).round() as i64
-
+    (a + b / 2) / b
 }

--- a/ring-lwe/src/test.rs
+++ b/ring-lwe/src/test.rs
@@ -62,7 +62,6 @@ mod tests {
     pub fn test_hom_prod() {
 
         let seed = None; //set the random seed
-        let params = Parameters::default();  // Adjust this if needed
 
         let params = Parameters::default();
         let (n, q, t, f) = (params.n, params.q, params.t, &params.f);


### PR DESCRIPTION
- extra line with params causing warning
- nearest int can be computed using integer division