### PR TITLE
update version to 0.1.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ring-lwe"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 description = "Implements the ring learning-with-errors public key encrpytion scheme."
 license = "MIT"


### PR DESCRIPTION
include ability to save/load public/private key files from command line, as well as ciphertext files.

use `clap` for command line argument parsing.